### PR TITLE
initial plugin support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-01-26  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/plugin.R (inlineCxxPlugin): Plugin support for Rcpp Attributes
+	and inline
+
 2018-01-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): New minor version

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -1,0 +1,31 @@
+## Copyright (C) 2018  Dirk Eddelbuettel
+##
+## This file is part of RcppSMC.
+##
+## RcppSMC is free software: you can redistribute it and/or modify it
+## under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 2 of the License, or
+## (at your option) any later version.
+##
+## RcppSMC is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with RcppSMC.  If not, see <http://www.gnu.org/licenses/>.
+
+inlineCxxPlugin <- function(...) {
+    ismacos <- Sys.info()[["sysname"]] == "Darwin"
+    openmpflag <- if (ismacos) "" else "$(SHLIB_OPENMP_CFLAGS)"
+    plugin <- Rcpp::Rcpp.plugin.maker(include.before = "#include <RcppSMC.h>",
+                                      libs           = paste(openmpflag,
+                                                             "$(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)"),
+                                      package        = "RcppSMC")
+    settings <- plugin()
+    settings$env$PKG_CPPFLAGS <- paste0("-I../inst/include ",
+                                       "-I", system.file("include", package="RcppArmadillo"), " ",
+                                       openmpflag)
+    if (!ismacos) settings$env$USE_CXX11 <- "yes"
+    settings
+}

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -9,6 +9,8 @@
     (Brian Ni in \ghpr{28}).
     \item The SMC library component can now be used in header-only mode
     (Martin Lysy in \ghpr{29}).
+    \item Plugin support was added for use via \code{cppFunction()} and other
+    Rcpp Attributes (or \pkg{inline} functions.
   }
 }
 

--- a/inst/include/RcppSMC.h
+++ b/inst/include/RcppSMC.h
@@ -1,5 +1,33 @@
 
-// todo
+// This file is part of RcppSMC.
+//
+// RcppSMC is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// RcppSMC is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with RcppSMC.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <RcppArmadillo.h>
+
+#include <adaptMethods.h>
+#include <blockpfgaussianopt.h>
+#include <history.h>
+#include <LinReg.h>
+#include <LinReg_LA_adapt.h>
+#include <LinReg_LA.h>
+#include <moveset.h>
+#include <nonLinPMMH.h>
+#include <pflineart.h>
+#include <pfnonlinbs.h>
 #include <population.h>
+#include <sampler.h>
+#include <smc-exception.h>
+#include <smctc.h>
+#include <staticModelAdapt.h>

--- a/inst/include/RcppSMC.h
+++ b/inst/include/RcppSMC.h
@@ -17,15 +17,8 @@
 #include <RcppArmadillo.h>
 
 #include <adaptMethods.h>
-#include <blockpfgaussianopt.h>
 #include <history.h>
-#include <LinReg.h>
-#include <LinReg_LA_adapt.h>
-#include <LinReg_LA.h>
 #include <moveset.h>
-#include <nonLinPMMH.h>
-#include <pflineart.h>
-#include <pfnonlinbs.h>
 #include <population.h>
 #include <sampler.h>
 #include <smc-exception.h>

--- a/inst/include/RcppSMC.h
+++ b/inst/include/RcppSMC.h
@@ -1,0 +1,5 @@
+
+// todo
+
+#include <RcppArmadillo.h>
+#include <population.h>


### PR DESCRIPTION
This now works:

```
edd@brad:~/git/rcppsmc(feature/plugin)$ Rscript -e \   # line breaks just for display 
             'Rcpp::cppFunction("bool foo(arma::vec x) { \
                    return smc::stableLogSumWeights(x); }", \
            depends=c("RcppSMC"))'
edd@brad:~/git/rcppsmc(feature/plugin)$ 
````

But the stub `RcppSMC.h` is of course too bare.  So @mlysy @adamjohansen : what classes should we expose / headers should be include?  All of tem?

Also: @mlysy if you have a better example handy ... just post it here. I'll include it proper copyright attribution to you.