### PR TITLE
Assignment Operator Corrections

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2018-03-18  Leah F. South  <leah.south@hdr.qut.edu.au>
+
+	* inst/include/moveset.h: Changed the assignment overloader to use
+	a const reference.
+	* inst/include/sampler.h: Added a missing return to the sampler
+	assignment overloading function.
+
 2018-03-18  Adam M. Johansen  <adam.johansen@gmail.com>
 
 	* inst/NEWS.Rd: Duplicate entry removed.

--- a/inst/include/moveset.h
+++ b/inst/include/moveset.h
@@ -89,7 +89,7 @@ namespace smc {
         void SetMoveFunctions(long nMoves, void (**pfNewMoves)(long, Space &, double &, Params &));
         
         ///Moveset assignment should allocate buffers and deep copy all members.
-        moveset<Space,Params> & operator= (moveset<Space,Params> & pFrom);
+        moveset<Space,Params> & operator= (const moveset<Space,Params> & pFrom);
     };
 
 
@@ -207,7 +207,7 @@ namespace smc {
     }
 
     template <class Space, class Params>
-    moveset<Space,Params> & moveset<Space,Params>::operator= (moveset<Space,Params> & pFrom)
+    moveset<Space,Params> & moveset<Space,Params>::operator= (const moveset<Space,Params> & pFrom)
     {
         SetInitialisor(pFrom.pfInitialise);
         SetMCMCFunction(pFrom.pfMCMC);

--- a/inst/include/sampler.h
+++ b/inst/include/sampler.h
@@ -334,6 +334,7 @@ namespace smc {
           }
           _copy(sFrom);
         }
+        return *this;
     }
 
     template <class Space, class Params>


### PR DESCRIPTION
Making the assignment operator for moveset take a const reference as its argument (rather than just a reference) and adding a missing return to the sampler assignment operator.

This is based on discussions in #33.