### PR TITLE
Using inheritance for the moveset

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,26 @@
+2018-07-05  Leah F. South  <leah.south@hdr.qut.edu.au>
+
+	* inst/include/moveset.h: Switching to inheritance for the
+	moveset while maintaining backwards compatibility (except
+	for the choice of multiple moves).
+	* inst/include/sampler.h: Idem.
+
+	* inst/include/blockpfgaussianopt.h: Idem.
+	* inst/include/LinReg.h: Idem.
+	* inst/include/LinReg_LA.h: Idem.
+	* inst/include/LinReg_LA_adapt.h: Idem.
+	* inst/include/nonLinPMMH.h: Idem.
+	* inst/include/pflineart.h: Idem.
+	* inst/include/pfnonlinbs.h: Idem.
+
+	* src/blockpfgaussianopt.cpp: Idem.
+	* src/LinReg.cpp: Idem.
+	* src/LinReg_LA.cpp: Idem.
+	* src/LinReg_LA_adapt.cpp: Idem.
+	* src/nonLinPMMH.cpp: Idem.
+	* src/pflineart.cpp: Idem.
+	* src/pfnonlinbs.cpp: Idem.
+
 2018-03-18  Leah F. South  <leah.south@hdr.qut.edu.au>
 
 	* inst/include/moveset.h: Changed the assignment overloader to use

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,12 +9,12 @@ LinReg_impl <- function(Data, lNumber) {
     .Call(`_RcppSMC_LinReg_impl`, Data, lNumber)
 }
 
-LinRegLA_adapt_impl <- function(Data, lNumber, resampTol, tempTol) {
-    .Call(`_RcppSMC_LinRegLA_adapt_impl`, Data, lNumber, resampTol, tempTol)
-}
-
 LinRegLA_impl <- function(Data, intemps, lNumber) {
     .Call(`_RcppSMC_LinRegLA_impl`, Data, intemps, lNumber)
+}
+
+LinRegLA_adapt_impl <- function(Data, lNumber, resampTol, tempTol) {
+    .Call(`_RcppSMC_LinRegLA_adapt_impl`, Data, lNumber, resampTol, tempTol)
 }
 
 nonLinPMMH_impl <- function(data, lNumber, lMCMCits) {

--- a/inst/include/LinReg.h
+++ b/inst/include/LinReg.h
@@ -38,10 +38,22 @@ namespace LinReg {
 
     rad_obs data;
     double mean_x;
-    
+	
     double logWeight(long lTime, const rad_state & value);
     double logPosterior(long lTime, const rad_state & value);
-    void fInitialise(rad_state & value, double & logweight, smc::nullParams & param);
-    void fMove(long lTime, rad_state & value, double & logweight, smc::nullParams & param);
-    bool fMCMC(long lTime, rad_state & value, double & logweight, smc::nullParams & param);
+	
+	//A derived class for the moves
+    class LinReg_move:
+    public smc::moveset<rad_state,smc::nullParams>
+    {
+    public:
+        void pfInitialise(rad_state & value, double & logweight, smc::nullParams & param);
+        void pfMove(long lTime, rad_state & value, double & logweight, smc::nullParams & param);
+        bool pfMCMC(long lTime, rad_state & value, double & logweight, smc::nullParams & param);
+
+        ~LinReg_move() {};
+
+    };
+	
+	smc::moveset<rad_state,smc::nullParams> * myMove;
 }

--- a/inst/include/LinReg_LA.h
+++ b/inst/include/LinReg_LA.h
@@ -42,15 +42,26 @@ namespace LinReg_LA {
     double mean_x;
     long lIterates;
     arma::vec temps;
-    
-    double logLikelihood(const rad_state & value);
+	
+	double logLikelihood(const rad_state & value);
     double logPrior(const rad_state & value);
+	
+	//A derived class for the moves
+    class LinReg_LA_move:
+    public smc::moveset<rad_state,smc::nullParams>
+    {
+    public:
     
-    void fInitialise(rad_state & value, double & logweight, smc::nullParams & param);
-    void fMove(long lTime, rad_state & value, double & logweight, smc::nullParams & param);
-    bool fMCMC(long lTime, rad_state & value, double & logweight, smc::nullParams & param);
+        void pfInitialise(rad_state & value, double & logweight, smc::nullParams & param);
+        void pfMove(long lTime, rad_state & value, double & logweight, smc::nullParams & param);
+        bool pfMCMC(long lTime, rad_state & value, double & logweight, smc::nullParams & param);
+
+        ~LinReg_LA_move() {};
+
+    };
     
     double integrand_ps(long,const rad_state &, void *);
     double width_ps(long, void *);
     
+	smc::moveset<rad_state,smc::nullParams>* myMove;
 }

--- a/inst/include/LinReg_LA_adapt.h
+++ b/inst/include/LinReg_LA_adapt.h
@@ -45,16 +45,26 @@ namespace LinReg_LA_adapt {
     long lIterates;
     double rho;
     
-    double logLikelihood(const rad_state & value);
-    double logPrior(const rad_state & value);
-    
-    void fInitialise(rad_state & value, double & logweight, smc::staticModelAdapt & param);
-    void fMove(long lTime, rad_state & value, double & logweight, smc::staticModelAdapt & param);
-    bool fMCMC(long lTime, rad_state & value, double & logweight, smc::staticModelAdapt & param);
-    
     double integrand_ps(long,const rad_state &, void *);
     double width_ps(long, void *);
-    
+	
+	double logLikelihood(const rad_state & value);
+    double logPrior(const rad_state & value);
+		
+    //A derived class for the moves
+    class rad_move:
+    public smc::moveset<rad_state,smc::staticModelAdapt>
+    {
+    public:
+	
+        void pfInitialise(rad_state & value, double & logweight, smc::staticModelAdapt & param);
+        void pfMove(long lTime, rad_state & value, double & logweight, smc::staticModelAdapt & param);
+        bool pfMCMC(long lTime, rad_state & value, double & logweight, smc::staticModelAdapt & param);
+
+        ~rad_move() {};
+
+    };
+	    
     //A derived class for adaptation which adapts parameters of type smc::staticModelAdapt
     class rad_adapt:
     public smc::adaptMethods<rad_state,smc::staticModelAdapt>
@@ -90,4 +100,5 @@ namespace LinReg_LA_adapt {
 
     smc::sampler<rad_state,smc::staticModelAdapt> * Sampler;
     smc::adaptMethods<rad_state,smc::staticModelAdapt> * myAdapt;
+	smc::moveset<rad_state,smc::staticModelAdapt>* myMove;
 }

--- a/inst/include/blockpfgaussianopt.h
+++ b/inst/include/blockpfgaussianopt.h
@@ -23,6 +23,18 @@
 #include "smctc.h"
 
 namespace BSPFG {    
-    void fInitialise(arma::vec & value, double & logweight, smc::nullParams & param);
-    void fMove(long lTime, arma::vec & value, double & logweight, smc::nullParams & param);
+    //A derived class for the moves
+    class BSPFG_move:
+    public smc::moveset<arma::vec,smc::nullParams>
+    {
+    public:
+	
+        void pfInitialise(arma::vec & value, double & logweight, smc::nullParams & param);
+        void pfMove(long lTime, arma::vec & value, double & logweight, smc::nullParams & param);
+		
+        ~BSPFG_move() {};
+
+    };
+	
+	smc::moveset<arma::vec,smc::nullParams>* myMove;
 }

--- a/inst/include/moveset.h
+++ b/inst/include/moveset.h
@@ -1,10 +1,10 @@
 // -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
-// moveset.h: Rcpp integration of SMC library -- sampler proposal moves 
+// moveset.h: Rcpp integration of SMC library -- sampler proposal moves
 //
 // Copyright (C) 2008 - 2009  Adam Johansen
 // Copyright (C) 2017         Adam Johansen, Dirk Eddelbuettel and Leah South
-// 
+//
 // This file is part of RcppSMC.
 //
 // RcppSMC is free software: you can redistribute it and/or modify it
@@ -33,12 +33,12 @@
 #include "population.h"
 
 namespace smc {
-	
+
 	/// A template class for a set of moves for use in an SMC samplers framework.
     template <class Space, class Params> class moveset {
- 
+
     private:
-	
+
         ///Default functions (only needed so that they can be overriden for backwards compatibility)
         ///The function which initialises a single particle.
         void (*defaultInitialise)(Space &, double &, Params &);
@@ -46,7 +46,7 @@ namespace smc {
         void (*defaultMove)(long, Space &, double &, Params &);
         ///One iteration of a Markov Chain Monte Carlo move for a single particle.
         bool (*defaultMCMC)(long, Space &,double &, Params &);
-		
+
     public:
 
 	    ///Create a completely unspecified moveset
@@ -56,7 +56,7 @@ namespace smc {
         moveset(void (*pfInit)(Space &, double &, Params &),
         void (*pfNewMove)(long, Space &,double &, Params &),
         bool (*pfNewMCMC)(long,Space &,double &, Params &));
-		
+
         /// Free the workspace allocated for the algorithm parameters.
         virtual ~moveset() {
         }
@@ -75,15 +75,15 @@ namespace smc {
                 return 0;
             }
         }
-		        
+
         ///Initialise the population of particles
-        void DoInit(population<Space> & pFrom, long N, Params &);
+        virtual void DoInit(population<Space> & pFrom, long N, Params &);
         ///Perform an MCMC move on the particles
-        bool DoMCMC(long lTime, population<Space> & pFrom, long N, int nRepeats, int & nAccepted, Params &);
+        virtual bool DoMCMC(long lTime, population<Space> & pFrom, long N, int nRepeats, int & nAccepted, Params &);
         ///Select an appropriate move at time lTime and apply it to pFrom
-        void DoMove(long lTime, population<Space> & pFrom,long N, Params &);
+        virtual void DoMove(long lTime, population<Space> & pFrom,long N, Params &);
     };
-	
+
 
     /// The argument free smc::moveset constructor simply sets the number of available moves to zero and sets
     /// all of the associated function pointers to NULL.

--- a/inst/include/moveset.h
+++ b/inst/include/moveset.h
@@ -39,7 +39,7 @@ namespace smc {
  
     private:
 	
-		//Defaults functions (only needed so that they can be overriden for backwards compatibility)
+        ///Default functions (only needed so that they can be overriden for backwards compatibility)
         ///The function which initialises a single particle.
         void (*defaultInitialise)(Space &, double &, Params &);
         ///The functions which perform actual moves on a single particle.
@@ -68,7 +68,13 @@ namespace smc {
         virtual void pfMove(long time, Space & value, double & weight, Params & myParams) {(*defaultMove)(time,value,weight,myParams);}
 
         /// Holder function for updates to be done at the end of each iteration.
-        virtual bool pfMCMC(long time, Space & value,double & weight, Params & myParams) {return (*defaultMCMC)(time,value,weight,myParams);}
+        virtual bool pfMCMC(long time, Space & value,double & weight, Params & myParams) {
+            if(defaultMCMC){
+                return (*defaultMCMC)(time,value,weight,myParams);
+            } else{
+                return 0;
+            }
+        }
 		        
         ///Initialise the population of particles
         void DoInit(population<Space> & pFrom, long N, Params &);

--- a/inst/include/moveset.h
+++ b/inst/include/moveset.h
@@ -33,133 +33,47 @@
 #include "population.h"
 
 namespace smc {
-
-    /// A template class for a set of moves for use in an SMC samplers framework.
-    template <class Space, class Params> class moveset
-    {
-    private:
-        ///The number of moves which are present in the set
-        long number;
-        ///The function which initialises a single particle.
-        void (*pfInitialise)(Space &, double &, Params &);
-        ///The function which selects a move for a given particle at a given time.
-        long (*pfMoveSelect)(long , const Space &, const double &, Params &);
-        ///The functions which perform actual moves on a single particle.
-        void (**pfMoves)(long, Space &, double &, Params &);
-        ///One iteration of a Markov Chain Monte Carlo move for a single particle.
-        bool (*pfMCMC)(long, Space &,double &, Params &);
-
+	
+	/// A template class for a set of moves for use in an SMC samplers framework.
+    template <class Space, class Params> class moveset {
+ 
     public:
-        ///Create a completely unspecified moveset
-        moveset();
-        ///Create a reduced moveset with a single move
-        moveset(void (*pfInit)(Space &, double &, Params &),
-        void (*pfNewMoves)(long, Space &,double &, Params &),
-        bool (*pfNewMCMC)(long,Space &,double &, Params &));
-        ///Create a fully specified moveset
-        moveset(void (*pfInit)(Space &, double &, Params &),long (*pfMoveSelector)(long , const Space &, const double &, Params &), 
-        long nMoves, void (**pfNewMoves)(long, Space &,double &, Params &),
-        bool (*pfNewMCMC)(long,Space &, double &, Params &));
-        
+
+        /// Free the workspace allocated for the algorithm parameters.
+        virtual ~moveset() {
+        }
+
+        /// Holder function for updates to be done before the move step.
+        virtual void pfInitialise(Space &, double &, Params &) {}
+
+        /// Holder function for updates to be done before the MCMC step.
+        virtual void pfMove(long, Space &, double &, Params &) {}
+
+        /// Holder function for updates to be done at the end of each iteration.
+        virtual bool pfMCMC(long, Space &,double &, Params &) {return 0;}
+		        
         ///Initialise the population of particles
         void DoInit(population<Space> & pFrom, long N, Params &);
         ///Perform an MCMC move on the particles
         bool DoMCMC(long lTime, population<Space> & pFrom, long N, int nRepeats, int & nAccepted, Params &);
         ///Select an appropriate move at time lTime and apply it to pFrom
         void DoMove(long lTime, population<Space> & pFrom,long N, Params &);
-        
-        ///Free the memory used for the array of move pointers when deleting
-        ~moveset();
-
-        /// \brief Set the initialisation function.
-        /// \param pfInit is a function which returns a particle generated according to the initial distribution 
-        void SetInitialisor( void (*pfInit)(Space &, double &, Params &))
-        {pfInitialise = pfInit;}
-
-        /// \brief Set the MCMC function
-        /// \param pfNewMCMC  The function which performs an MCMC move
-        void SetMCMCFunction(bool (*pfNewMCMC)(long,Space &,double &, Params &)) {pfMCMC = pfNewMCMC;}
-
-        /// \brief Set the move selection function
-        /// \param pfMoveSelectNew returns the index of move to perform at the specified time given the specified particle
-        void SetMoveSelectionFunction(long (*pfMoveSelectNew)(long , const Space &, const double &, Params &))
-        {pfMoveSelect = pfMoveSelectNew;};
-
-        ///Set the individual move functions to the supplied array of such functions
-        void SetMoveFunctions(long nMoves, void (**pfNewMoves)(long, Space &, double &, Params &));
-        
-        ///Moveset assignment should allocate buffers and deep copy all members.
-        moveset<Space,Params> & operator= (const moveset<Space,Params> & pFrom);
     };
-
-
-    /// The argument free smc::moveset constructor simply sets the number of available moves to zero and sets
-    /// all of the associated function pointers to NULL.
-    template <class Space, class Params>
-    moveset<Space,Params>::moveset()
-    {
-        number = 0;
-
-        pfInitialise = NULL;
-        pfMoveSelect = NULL;
-        pfMoves = NULL;
-        pfMCMC = NULL;
-    }
-
-    /// The three argument moveset constructor creates a new set of moves and sets all of the relevant function
-    /// pointers to the supplied values. Only a single move should exist if this constructor is used.
-    /// \param pfInit The function which should be used to initialise a particle when the system is initialised
-    /// \param pfNewMoves An functions which moves particles at a specified time to a new location
-    /// \param pfNewMCMC The function which should be called to apply an MCMC move (if any)
-    template <class Space, class Params>
-    moveset<Space,Params>::moveset(void (*pfInit)(Space &, double &, Params &),
-    void (*pfNewMoves)(long, Space &,double &, Params &),
-    bool (*pfNewMCMC)(long,Space &,double &, Params &))
-    {
-        SetInitialisor(pfInit);
-        SetMoveSelectionFunction(NULL);
-        pfMoves = NULL; //This presents an erroneous deletion by the following call
-        SetMoveFunctions(1, &pfNewMoves);
-        SetMCMCFunction(pfNewMCMC);
-    }
-
-    /// The five argument moveset constructor creates a new set of moves and sets all of the relevant function
-    /// pointers to the supplied values.
-    /// \param pfInit The function which should be used to initialise particles when the system is initialised
-    /// \param pfMoveSelector The function which selects a move to apply, at a specified time, to a specified particle
-    /// \param nMoves The number of moves which are defined in general
-    /// \param pfNewMoves An array of functions which moves particles at a specified time to a new location
-    /// \param pfNewMCMC The function which should be called to apply an MCMC move (if any)
-    template <class Space, class Params>
-    moveset<Space,Params>::moveset(void (*pfInit)(Space &, double &, Params &),long (*pfMoveSelector)(long ,const Space &, const double &, Params &), 
-    long nMoves, void (**pfNewMoves)(long, Space &,double &, Params &),
-    bool (*pfNewMCMC)(long,Space &,double &, Params &))
-    {
-        SetInitialisor(pfInit);
-        SetMoveSelectionFunction(pfMoveSelector);
-        pfMoves = NULL; //This presents an erroneous deletion by the following call
-        SetMoveFunctions(nMoves, pfNewMoves);
-        SetMCMCFunction(pfNewMCMC);
-    }
-
-    template <class Space, class Params>
-    moveset<Space,Params>::~moveset()
-    {    if(pfMoves)
-        delete [] pfMoves;
-    }
 
 
     template <class Space, class Params>
     void moveset<Space,Params>::DoInit(population<Space> & pFrom, long N, Params & params) {
         for (long i=0; i<N; i++){
-            (*pfInitialise)(pFrom.GetValueRefN(i),pFrom.GetLogWeightRefN(i),params);
+            pfInitialise(pFrom.GetValueRefN(i),pFrom.GetLogWeightRefN(i),params);
         }
     }
 
     template <class Space, class Params>
     bool moveset<Space,Params>::DoMCMC(long lTime, population<Space> & pFrom, long N, int nRepeats, int & nAccepted, Params & params)
     {
-        if(pfMCMC && nRepeats>0) {
+		// LEAH NOTE: NEED TO CHECK FOR EXISTENCE OF A FUNCTION HERE
+		//if(pfMCMC && nRepeats>0) {
+		if(nRepeats>0) {
             nAccepted = 0;
             for (int j=0; j<nRepeats; j++){
                 for (long i=0; i<N; i++){
@@ -177,43 +91,9 @@ namespace smc {
     template <class Space, class Params>
     void moveset<Space,Params>::DoMove(long lTime, population<Space> & pFrom, long N, Params & params)
     {
-        if(number > 1)
         for (long i=0; i<N; i++){
-            pfMoves[pfMoveSelect(lTime,pFrom.GetValueRefN(i),pFrom.GetLogWeightRefN(i),params)](lTime,pFrom.GetValueRefN(i),pFrom.GetLogWeightRefN(i),params);
+            pfMove(lTime,pFrom.GetValueRefN(i),pFrom.GetLogWeightRefN(i),params);
         }
-        else
-        
-        for (long i=0; i<N; i++){
-            pfMoves[0](lTime,pFrom.GetValueRefN(i),pFrom.GetLogWeightRefN(i),params);
-        }
-    }
-
-    /// \param nMoves The number of moves which are defined in general.
-    /// \param pfNewMoves An array of functions which moves particles at a specified time to a new location
-    ///
-    /// The move functions accept two arguments, the first of which corresponds to the system evolution time and the
-    /// second to an initial particle position and the second to a weighted starting position. It returns a new 
-    /// weighted position corresponding to the moved particle.
-    template <class Space, class Params>
-    void moveset<Space,Params>::SetMoveFunctions(long nMoves,void (**pfNewMoves)(long,Space &,double &, Params &))
-    {
-        number = nMoves;
-        if(pfMoves)
-        delete [] pfMoves;
-        pfMoves = (void (**)(long int, Space &, double &, Params &)) new void* [nMoves];
-        for(int i = 0; i < nMoves; i++)
-        pfMoves[i] = pfNewMoves[i];
-        return;
-    }
-
-    template <class Space, class Params>
-    moveset<Space,Params> & moveset<Space,Params>::operator= (const moveset<Space,Params> & pFrom)
-    {
-        SetInitialisor(pFrom.pfInitialise);
-        SetMCMCFunction(pFrom.pfMCMC);
-        SetMoveSelectionFunction(pFrom.pfMoveSelect);
-        SetMoveFunctions(pFrom.number, pFrom.pfMoves);       
-        return *this;
     }
 }
 #endif

--- a/inst/include/nonLinPMMH.h
+++ b/inst/include/nonLinPMMH.h
@@ -33,9 +33,21 @@ namespace nonLinPMMH {
     arma::vec y; //data
     
     double logPrior(const parameters & proposal);
-    void fInitialise(double & value, double & logweight, smc::nullParams & param);
-    void fMove(long lTime, double & value, double & logweight, smc::nullParams & param);
+	
+    //A derived class for the moves
+    class nonLinPMMH_move:
+    public smc::moveset<double,smc::nullParams>
+    {
+    public:
+	    
+        void pfInitialise(double & value, double & logweight, smc::nullParams & param);
+        void pfMove(long lTime, double & value, double & logweight, smc::nullParams & param);
+
+        ~nonLinPMMH_move() {};
+
+    };
     
     parameters theta_prop;
+	smc::moveset<double,smc::nullParams>* myMove;
 }
 

--- a/inst/include/pflineart.h
+++ b/inst/include/pflineart.h
@@ -36,15 +36,27 @@ namespace pflineart {
     public:
         arma::vec x_pos, y_pos;
     };
+	
+	double logLikelihood(long lTime, const cv_state & X);
+	
+	//A derived class for the moves
+    class pflineart_move:
+    public smc::moveset<cv_state,smc::nullParams>
+    {
+    public:
+        
+		void pfInitialise(cv_state & value, double & logweight, smc::nullParams & param);
+        void pfMove(long lTime, cv_state & value, double & logweight, smc::nullParams & param);
 
-    double logLikelihood(long lTime, const cv_state & X);
+        ~pflineart_move() {};
 
-    void fInitialise(cv_state & value, double & logweight, smc::nullParams & param);
-    void fMove(long lTime, cv_state & value, double & logweight, smc::nullParams & param);
+    };
 
     double integrand_mean_x(const cv_state&, void*);
     double integrand_mean_y(const cv_state&, void*);
     double integrand_var_x(const cv_state&, void*);
     double integrand_var_y(const cv_state&, void*);
+	
+	smc::moveset<cv_state,smc::nullParams>* myMove;
 
 }

--- a/inst/include/pfnonlinbs.h
+++ b/inst/include/pfnonlinbs.h
@@ -28,11 +28,24 @@
 #include "smctc.h"
 
 namespace nonlinbs {
-    double logLikelihood(long lTime, const double & X);
-    
-    void fInitialise(double & value, double & logweight, smc::nullParams & param);
-    void fMove(long lTime, double & value, double & logweight, smc::nullParams & param);
+	
+	double logLikelihood(long lTime, const double & X);
+	
+	//A derived class for the moves
+    class nonlinbs_move:
+    public smc::moveset<double,smc::nullParams>
+    {
+    public:
+	
+        void pfInitialise(double & value, double & logweight, smc::nullParams & param);
+        void pfMove(long lTime, double & value, double & logweight, smc::nullParams & param);
+
+        ~nonlinbs_move() {};
+
+    };
 
     double integrand_mean_x(const double&, void*);
     double integrand_var_x(const double&, void*);
+	
+	smc::moveset<double,smc::nullParams>* myMove;
 }

--- a/inst/include/sampler.h
+++ b/inst/include/sampler.h
@@ -253,7 +253,7 @@ namespace smc {
         pAdapt = new adaptMethods<Space,Params>;
         adaptBelong = 1;
         nRepeats = 1;
-		
+
 		// Adding the moveset
 		pMoves = pNewMoves;
 		movesetBelong = 0;
@@ -282,7 +282,7 @@ namespace smc {
         pAdapt = new adaptMethods<Space,Params>;
         adaptBelong = 1;
         nRepeats = 1;
-		
+
 		// Creating a default moveset
         pMoves = new moveset<Space,Params>;
         movesetBelong = 1;
@@ -336,8 +336,8 @@ namespace smc {
         // pMoves = sFrom.pMoves;
         // ///A flag to track whether the moveset object needs to be included in this destructor.
         // movesetBelong = sFrom.movesetBelong sFrom.movesetBelong;
-		
-		
+
+
         /// The additional algorithm parameters.
         algParams = sFrom.algParams;
         if(sFrom.adaptBelong) {

--- a/inst/include/smctc.h
+++ b/inst/include/smctc.h
@@ -22,15 +22,15 @@
 //
 
 /// \mainpage smctc -- A Template Class Library for SMC Simulation
-///  
+///
 /// \version 1.0
 /// \author Adam M. Johansen
 ///
 /// \section intro_sec Summary
 ///
-/// The SMC template class library (SMCTC) is intended to be used to implement SMC 
+/// The SMC template class library (SMCTC) is intended to be used to implement SMC
 /// algorithms ranging from simple particle filter to complicated SMC algorithms
-/// from simple particle filters to the SMC samplers of Del Moral, Doucet and Jasra (2006) 
+/// from simple particle filters to the SMC samplers of Del Moral, Doucet and Jasra (2006)
 /// within a generic framework.
 ///
 /// \section license License
@@ -47,18 +47,18 @@
 ///
 /// You should have received a copy of the GNU General Public License
 /// along with SMCTC.  If not, see <http://www.gnu.org/licenses/>.
-/// 
+///
 /// The software is still in development but is thought to be sufficiently fully-featured and
 /// stable for use.
 ///
 /// \section using_sec Using the Template Library
 ///
-/// In order to use the template libary it is necessary to place the set of header files in 
-/// a suitable include directory and then to instantiate the various classes with the 
+/// In order to use the template libary it is necessary to place the set of header files in
+/// a suitable include directory and then to instantiate the various classes with the
 /// appropriate type for your sampler.
 ///
 /// For implementation details, please see the accompanying user guide.
-/// 
+///
 ///
 /// \section example_sec Examples
 ///
@@ -68,9 +68,9 @@
 /// nonlinear, nongaussian state space models.
 ///
 /// \subsection SMC Samplers for Rare Event Simulation
-/// 
-/// The main.cc file provides an example of a use of the template library to estimate 
-/// Gaussian tail probabilities within an SMC samplers framework by making use of a sequence 
+///
+/// The main.cc file provides an example of a use of the template library to estimate
+/// Gaussian tail probabilities within an SMC samplers framework by making use of a sequence
 /// of intermediate distributions defined by introducing a potential function which
 /// varies from flat to being very close to an indicator function on the tail event.
 ///
@@ -108,9 +108,9 @@
 
 namespace smc {}
 
-/// The standard namespace 
+/// The standard namespace
 
-///     The classes provided within the standard libraries reside within this namespace and 
+///     The classes provided within the standard libraries reside within this namespace and
 ///     the TDSMC class library adds a number of additional operator overloads to some of
 ///     the standard classes to allow them to deal with our structures.
 

--- a/src/LinReg.cpp
+++ b/src/LinReg.cpp
@@ -23,7 +23,7 @@
 #include "LinReg.h"
 #include <RcppArmadillo.h>
 
-#include <cstdio> 
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <math.h>
@@ -44,44 +44,44 @@ using namespace LinReg;
 
 // LinReg() function callable from R via Rcpp::
 // [[Rcpp::export]]
-Rcpp::List LinReg_impl(arma::mat Data, unsigned long lNumber) {  
+Rcpp::List LinReg_impl(arma::mat Data, unsigned long lNumber) {
 
     long lIterates;
 
-    try {       
+    try {
         // Load observations -- or rather copy them in from R
         lIterates = Data.n_rows;
         data.y = Data.col(0);
         data.x = Data.col(1);
         mean_x = arma::sum(data.x)/lIterates;
-        
+
         //Initialise and run the sampler
 		myMove = new LinReg_move;
         smc::sampler<rad_state,smc::nullParams> Sampler(lNumber, HistoryType::RAM, myMove);
-        
+
         Sampler.SetResampleParams(ResampleType::MULTINOMIAL, 0.5);
         Sampler.SetMcmcRepeats(10);
         Sampler.Initialise();
         Sampler.IterateUntil(lIterates-1);
-        
+
         arma::mat theta(lNumber,3);
         arma::vec weights = Sampler.GetParticleWeight();
-        
+
         for (unsigned int i = 0; i<lNumber; i++){
             theta.row(i) = Sampler.GetParticleValueN(i).theta.t();
         }
-        
+
         double logNC = Sampler.GetLogNCPath();
-		
+
 		delete myMove;
-        
+
         return Rcpp::List::create(Rcpp::Named("theta") = theta,Rcpp::Named("weights") = weights,
         Rcpp::Named("logNC") = logNC);
     }
     catch(smc::exception  e) {
         Rcpp::Rcout << e;
     }
-    return R_NilValue;              // to provide a return 
+    return R_NilValue;              // to provide a return
 }
 
 namespace LinReg {
@@ -89,7 +89,7 @@ namespace LinReg {
     ///The function corresponding to the log likelihood at specified time and position (up to normalisation)
 
     /// \param lTime        The current time (i.e. the index of the current distribution)
-    /// \param value        The state to consider 
+    /// \param value        The state to consider
     double logWeight(long lTime, const rad_state & value){
 
         double mean_reg = value.theta(0) + value.theta(1)*(data.x(lTime) - mean_x);
@@ -101,7 +101,7 @@ namespace LinReg {
     ///The function corresponding to the (unnormalised) log posterior at specified time and position
 
     /// \param lTime        The current time (i.e. the index of the current distribution)
-    /// \param value        The state to consider 
+    /// \param value        The state to consider
     double logPosterior(long lTime, const rad_state & value){
 
         double log_prior = -log(1000.0)- std::pow(value.theta(0) - 3000.0,2.0)/(2.0*1000.0*1000.0) -log(100.0)- std::pow(value.theta(1) - 185.0,2.0)/(2.0*100.0*100.0) + value.theta(2)-1.0/b_prior/expl(value.theta(2)) -value.theta(2)*(a_prior+1.0);
@@ -133,7 +133,7 @@ namespace LinReg {
         value.theta(0) = R::rnorm(3000.0,1000.0);
         value.theta(1) = R::rnorm(185.0,100.0);
         value.theta(2) = log(std::pow(R::rgamma(3,std::pow(2.0*300.0*300.0,-1.0)),-1.0));
-        
+
         logweight = logWeight(0, value);
     }
 
@@ -157,14 +157,14 @@ namespace LinReg {
     bool LinReg_move::pfMCMC(long lTime, rad_state & value, double & logweight, smc::nullParams & param)
     {
         double logposterior_curr = logPosterior(lTime, value);
-        
+
         rad_state value_prop;
         value_prop.theta = value.theta + cholCovRW*Rcpp::as<arma::vec>(Rcpp::rnorm(3));
-        
+
         double logposterior_prop = logPosterior(lTime, value_prop);
-        
+
         double MH_ratio = exp(logposterior_prop - logposterior_curr);
-        
+
         if (MH_ratio>R::runif(0,1)){
             value = value_prop;
             logposterior_curr = logposterior_prop;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -32,6 +32,19 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// LinRegLA_impl
+Rcpp::List LinRegLA_impl(arma::mat Data, arma::vec intemps, unsigned long lNumber);
+RcppExport SEXP _RcppSMC_LinRegLA_impl(SEXP DataSEXP, SEXP intempsSEXP, SEXP lNumberSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::mat >::type Data(DataSEXP);
+    Rcpp::traits::input_parameter< arma::vec >::type intemps(intempsSEXP);
+    Rcpp::traits::input_parameter< unsigned long >::type lNumber(lNumberSEXP);
+    rcpp_result_gen = Rcpp::wrap(LinRegLA_impl(Data, intemps, lNumber));
+    return rcpp_result_gen;
+END_RCPP
+}
 // LinRegLA_adapt_impl
 Rcpp::List LinRegLA_adapt_impl(arma::mat Data, unsigned long lNumber, double resampTol, double tempTol);
 RcppExport SEXP _RcppSMC_LinRegLA_adapt_impl(SEXP DataSEXP, SEXP lNumberSEXP, SEXP resampTolSEXP, SEXP tempTolSEXP) {
@@ -43,19 +56,6 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< double >::type resampTol(resampTolSEXP);
     Rcpp::traits::input_parameter< double >::type tempTol(tempTolSEXP);
     rcpp_result_gen = Rcpp::wrap(LinRegLA_adapt_impl(Data, lNumber, resampTol, tempTol));
-    return rcpp_result_gen;
-END_RCPP
-}
-// LinRegLA_impl
-Rcpp::List LinRegLA_impl(arma::mat Data, arma::vec intemps, unsigned long lNumber);
-RcppExport SEXP _RcppSMC_LinRegLA_impl(SEXP DataSEXP, SEXP intempsSEXP, SEXP lNumberSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::mat >::type Data(DataSEXP);
-    Rcpp::traits::input_parameter< arma::vec >::type intemps(intempsSEXP);
-    Rcpp::traits::input_parameter< unsigned long >::type lNumber(lNumberSEXP);
-    rcpp_result_gen = Rcpp::wrap(LinRegLA_impl(Data, intemps, lNumber));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -102,8 +102,8 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_RcppSMC_blockpfGaussianOpt_impl", (DL_FUNC) &_RcppSMC_blockpfGaussianOpt_impl, 3},
     {"_RcppSMC_LinReg_impl", (DL_FUNC) &_RcppSMC_LinReg_impl, 2},
-    {"_RcppSMC_LinRegLA_adapt_impl", (DL_FUNC) &_RcppSMC_LinRegLA_adapt_impl, 4},
     {"_RcppSMC_LinRegLA_impl", (DL_FUNC) &_RcppSMC_LinRegLA_impl, 3},
+    {"_RcppSMC_LinRegLA_adapt_impl", (DL_FUNC) &_RcppSMC_LinRegLA_adapt_impl, 4},
     {"_RcppSMC_nonLinPMMH_impl", (DL_FUNC) &_RcppSMC_nonLinPMMH_impl, 3},
     {"_RcppSMC_pfLineartBS_impl", (DL_FUNC) &_RcppSMC_pfLineartBS_impl, 4},
     {"_RcppSMC_pfNonlinBS_impl", (DL_FUNC) &_RcppSMC_pfNonlinBS_impl, 2},

--- a/src/blockpfgaussianopt.cpp
+++ b/src/blockpfgaussianopt.cpp
@@ -47,11 +47,10 @@ Rcpp::List blockpfGaussianOpt_impl(arma::vec data, long part, long lag)
     lIterates = y.size();
 
     //Initialise and run the sampler
-    smc::sampler<arma::vec,smc::nullParams> Sampler(lNumber, HistoryType::NONE);  
-    smc::moveset<arma::vec,smc::nullParams> Moveset(fInitialise, fMove, NULL);
+	myMove = new BSPFG_move;
+    smc::sampler<arma::vec,smc::nullParams> Sampler(lNumber, HistoryType::NONE, myMove);
 
     Sampler.SetResampleParams(ResampleType::SYSTEMATIC, 0.5);
-    Sampler.SetMoveSet(Moveset);
 
     Sampler.Initialise();
     Sampler.IterateUntil(lIterates - 1);
@@ -65,6 +64,8 @@ Rcpp::List blockpfGaussianOpt_impl(arma::vec data, long part, long lag)
     }
     
     double logNC = Sampler.GetLogNCPath();
+	
+	delete myMove;
 
     return Rcpp::List::create(Rcpp::_["weight"] = resWeights, Rcpp::_["values"] = resValues, Rcpp::_["logNC"] = logNC);
 }
@@ -77,7 +78,7 @@ namespace BSPFG {
     /// \param value The value of the particle being moved
     /// \param logweight The log weight of the particle being moved
     /// \param param Additional algorithm parameters
-    void fInitialise(arma::vec & value, double & logweight, smc::nullParams & param)
+    void BSPFG_move::pfInitialise(arma::vec & value, double & logweight, smc::nullParams & param)
     {
         value = arma::zeros<arma::vec>(lIterates);
         value(0) = R::rnorm(0.5 * y(0),1.0/sqrt(2.0));
@@ -90,7 +91,7 @@ namespace BSPFG {
     ///\param value The value of the particle being moved
     ///\param logweight The log weight of the particle being moved
     ///\param param Additional algorithm parameters
-    void fMove(long lTime, arma::vec & value, double & logweight, smc::nullParams & param)
+    void BSPFG_move::pfMove(long lTime, arma::vec & value, double & logweight, smc::nullParams & param)
     {
         if(lTime == 1) {
             value(lTime) = (value(lTime-1) + y(lTime))/2.0 + R::rnorm(0.0,1.0/sqrt(2.0));

--- a/src/pflineart.cpp
+++ b/src/pflineart.cpp
@@ -62,11 +62,9 @@ Rcpp::DataFrame pfLineartBS_impl(arma::mat data, unsigned long part, bool usef, 
         y.y_pos = data.col(1);
 
         //Initialise and run the sampler
-        smc::sampler<cv_state,smc::nullParams> Sampler(lNumber, HistoryType::NONE);  
-        smc::moveset<cv_state,smc::nullParams> Moveset(fInitialise, fMove, NULL);
-
+		myMove = new pflineart_move;
+        smc::sampler<cv_state,smc::nullParams> Sampler(lNumber, HistoryType::NONE, myMove);  
         Sampler.SetResampleParams(ResampleType::RESIDUAL, 0.5);
-        Sampler.SetMoveSet(Moveset);
         Sampler.Initialise();
 
         Rcpp::NumericVector Xm(lIterates), Xv(lIterates), Ym(lIterates), Yv(lIterates);
@@ -86,6 +84,8 @@ Rcpp::DataFrame pfLineartBS_impl(arma::mat data, unsigned long part, bool usef, 
 
             if (usef) fun(Xm, Ym);
         }
+		
+		delete myMove;
 
         return Rcpp::DataFrame::create(Rcpp::Named("Xm") = Xm,
         Rcpp::Named("Xv") = Xv,
@@ -142,7 +142,7 @@ namespace pflineart {
     /// \param value The value of the particle being moved
     /// \param logweight The log weight of the particle being moved
     /// \param param Additional algorithm parameters
-    void fInitialise(cv_state & value, double & logweight, smc::nullParams & param)
+    void pflineart_move::pfInitialise(cv_state & value, double & logweight, smc::nullParams & param)
     {
         value.x_pos = R::rnorm(0.0,sqrt(var_s0));
         value.y_pos = R::rnorm(0.0,sqrt(var_s0));
@@ -158,7 +158,7 @@ namespace pflineart {
     ///\param value The value of the particle being moved
     ///\param logweight The log weight of the particle being moved
     /// \param param Additional algorithm parameters
-    void fMove(long lTime, cv_state & value, double & logweight, smc::nullParams & param)
+    void pflineart_move::pfMove(long lTime, cv_state & value, double & logweight, smc::nullParams & param)
     {
         value.x_pos += value.x_vel * Delta + R::rnorm(0.0,sqrt(var_s));
         value.x_vel += R::rnorm(0.0,sqrt(var_u));


### PR DESCRIPTION
Currently the package uses inheritance for parameter updates and pointers to functions for the moveset. This pull request is about switching to inheritance for the moveset while maintaining backwards compatibility.

The biggest change is in the moveset.h file, followed by the sampler.h file. All examples had to be changed (in a similar way). I'm not sure what's up with the diff file for LinReg_LA.cpp (the actual changes are similar to other examples).