### PR TITLE
add missing documentation to nonLinPMMH() (or moving documentation to roxygen)

### DIFF
--- a/man/nonLinPMMH.Rd
+++ b/man/nonLinPMMH.Rd
@@ -22,7 +22,7 @@ parameters, the log-prior, the log-likelihood and the MH acceptance rates up to
 the current iteration; defaults to \code{FALSE} in which case only percentage 
 completion of the procedure is printed.}
 
-\item{msg_feq}{Specifies the printing fequency of percentage completion or, if
+\item{msg_freq}{Specifies the printing frequency of percentage completion or, if
 \code{verbose = TRUE}, percentage completion as well as convergence
 diagnostics.}
 

--- a/man/nonLinPMMH.Rd
+++ b/man/nonLinPMMH.Rd
@@ -3,7 +3,7 @@
 \title{Particle marginal Metropolis-Hastings for a non-linear state space model.}
 \usage{
 nonLinPMMH(data, particles = 5000, iterations = 10000, burnin = 0,
-  plot = FALSE)
+  verbose = FALSE, msg_freq = 100, plot = FALSE)
 }
 \arguments{
 \item{data}{A vector of the observed data.}
@@ -15,6 +15,16 @@ filtering estimates of the likelihood.}
 
 \item{burnin}{The number of iterations to remove from the beginning of the MCMC chain
 (for plotting purposes only).}
+
+\item{verbose}{Logical; if \code{TRUE} convergence diagnostics are printed to 
+the console (each \code{msg_freq} iterations) displaying the running means of 
+parameters, the log-prior, the log-likelihood and the MH acceptance rates up to 
+the current iteration; defaults to \code{FALSE} in which case only percentage 
+completion of the procedure is printed.}
+
+\item{msg_feq}{Specifies the printing fequency of percentage completion or, if
+\code{verbose = TRUE}, percentage completion as well as convergence
+diagnostics.}
 
 \item{plot}{A boolean variable to determine whether to plot the posterior estimates
 and MCMC chain.}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -7,11 +7,6 @@
 
 using namespace Rcpp;
 
-#ifdef RCPP_USE_GLOBAL_ROSTREAM
-Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
-Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
-#endif
-
 // LinReg_impl
 Rcpp::List LinReg_impl(arma::mat Data, unsigned long lNumber);
 RcppExport SEXP _RcppSMC_LinReg_impl(SEXP DataSEXP, SEXP lNumberSEXP) {


### PR DESCRIPTION
Pulled out the discussion from #50, and regarding to @adamjohansen and @LeahPrice , we can discuss to either deal with

1. adding documentation to verbose, msg_freq arguments of nonLinPMMH(), maybe I missed something but I hope it's solved more or less.

2. moving to roxygen2, and if so, I'll get this done within this PR.

In general, moving to roxygen comments should, firstly, be mostly copy and paste from the *.Rd files already present, thus not a big deal, and secondly, we might identify and close missing spots in the documentation.

(obviously, that's not my call at all, just collecting some ideas around here!)

