### PR TITLE
add URL and BugReports to DESCRIPTION

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-05-21  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (URL, BugReports): Added
+
 2021-05-20  Dirk Eddelbuettel  <edd@debian.org>
 
 	* src/RcppExports.cpp: Updated

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,3 +14,5 @@ LazyLoad: yes
 Imports: Rcpp (>= 0.11.0), methods
 LinkingTo: Rcpp, RcppArmadillo
 LazyData: true
+URL: https://github.com/rcppsmc/rcppsmc, https://dirk.eddelbuettel.com/code/rcpp.smc.html
+BugReports: https://github.com/rcppsmc/rcppsmc/issues


### PR DESCRIPTION
A quick 'maintenance' PR to update DESCRIPTION for URL and BugReports fields which, while not mandated by CRAN Repository Policy, are becoming more common and are helpful for different integrations on top of CRAN.  

No other changes.