### PR TITLE
Add facilities that allow for tracking of ancestral lines

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2021-06-23  Ilya Zarubin  <ilya.a.zarub@gmail.com>
+
+	* inst/include/history.h: add facilities for tracking of ancestral lines
+	(mostly additions to the historyelement class)
+	* inst/include/sampler.h: add computation of ancestral lines making us of
+	updated facilities from the historyelement class; conditional switch
+	allowing for an additional HistoryType::AL
+
 2021-05-21  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (URL, BugReports): Added
@@ -47,7 +55,7 @@
 
 2021-01-12  Dirk Eddelbuettel  <edd@debian.org>
 
-        * .github/workflows/ci.yaml: Add CI runner using r-ci
+    * .github/workflows/ci.yaml: Add CI runner using r-ci
 	* README.md: Add new badge
 
 2020-08-29  Dirk Eddelbuettel  <edd@debian.org>

--- a/inst/include/history.h
+++ b/inst/include/history.h
@@ -67,6 +67,7 @@ namespace smc {
         int nAccepted; //!< Number of MCMC moves accepted during this iteration.
         int nRepeat; //!< Number of MCMC iterations performed at this iteration (per particle)
         population<Space> pop; //!< The particles themselves (values and weights)
+        arma::Col<unsigned int> ancestorIndices = arma::Col<unsigned int>(number);
         historyflags flags; //!< Flags associated with this iteration.
 
     public:
@@ -88,13 +89,20 @@ namespace smc {
         population<Space> GetValues(void) const { return pop; }
         /// Returns a reference to the current particle set.
         population<Space> & GetRefs(void) { return pop; }
+        /// Sets the ancestor indices of the current particle set.
+        void SetAIndices(const arma::Col<unsigned int> & newAindices) {
+            ancestorIndices = newAindices;
+        }
+        /// Returns the ancestor indices of the current particle set.
+        arma::Col<unsigned int> GetAIndices(void) const {return ancestorIndices;}
         /// Monte Carlo estimate of the expectation of the supplied function with respect to the empirical measure of the particle ensemble.
         long double Integrate(long lTime, double (*pIntegrand)(long,const Space&,void*), void* pAuxiliary) const;
         /// Monte Carlo estimate of the variance of the supplied function with respect to the empirical measure of the particle ensemble (to be used in second order trapezoidal correction).
         long double Integrate_Var(long lTime, double (*pIntegrand)(long,const Space&,void*), double Expectation, void* pAuxiliary) const;
-        /// Sets the particle set to the specified values.
+        /// Sets the particle set to the specified values excluding ancestors.
         void Set(long lNumber, const population<Space> &New, int inAccepted, int nRepeats, const historyflags &histflags){number = lNumber; pop = New; nAccepted = inAccepted; nRepeat = nRepeats; flags = histflags;};
-
+        /// Sets the particle set to the specified values including ancestors.
+        void Set(long lNumber, const population<Space> &New, int inAccepted, int nRepeats, const historyflags &histflags, const arma::Col<unsigned int> & newAindices){number = lNumber; pop = New; nAccepted = inAccepted; nRepeat = nRepeats; flags = histflags; ancestorIndices = newAindices;};
         /// Returns the number of MCMC moves accepted during this iteration.
         int AcceptCount(void) {return nAccepted; }
         /// Returns the number of MCMC iterations performed during this iteration.


### PR DESCRIPTION
So here are the discussed changes to allow for tracking of ancestral lines (just squashed my commits for the first time so the commit history will be cleaner than last time :) ). 

I agree with @adamjohansen about the documentation; we have the comments to the include files and the .Rd files for functions that are meant to be called via R or am I mistaken?

@eddelbuettel I upgraded `Rcpp` to the Drat version, so this time no changes to the export-files I think.

Hope the CI passes this time, I'll check this first thing in the morning!