### PR TITLE
Use std::pow, update README, roll minor version (closes #64)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2021-09-08  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll minor version
+
+	* inst/include/conditionalSampler.h: Use std::pow
+
+	* README.md: Belatedly add Ilya
+
 2021-09-01  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.2.4

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RcppSMC
 Type: Package
 Title: Rcpp Bindings for Sequential Monte Carlo
-Version: 0.2.4
-Date: 2021-09-01
+Version: 0.2.4.1
+Date: 2021-09-08
 Author: Dirk Eddelbuettel, Adam M. Johansen, Leah F. South and Ilya Zarubin
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: R access to the Sequential Monte Carlo Template Classes

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For support and discussion please make us of the [rcppsmc mailing list](https://
 
 ### Authors
 
-Dirk Eddelbuettel, Adam M. Johansen and Leah F. South
+Dirk Eddelbuettel, Adam M. Johansen, Leah F. South and Ilya Zarubin
 
 ### License
 

--- a/inst/include/conditionalSampler.h
+++ b/inst/include/conditionalSampler.h
@@ -627,7 +627,7 @@ namespace smc {
         Space val;
         double unw;
         double nw;
-        int roundDigits = pow(10, digits);
+        int roundDigits = std::pow(10, digits);
         for(int i = 0; i < pPopulation.GetNumber() - 1; ++i){
             val = pPopulation.GetValueN(i);
 


### PR DESCRIPTION
This corrects #64, and while at it, adds Ivan to the README and rolls the minor release.

We can probably just relabel this as is as 0.2.5 -- or is there something else worth sweeping up now?