### PR TITLE
remove 'using namespace std' avoiding clash over std::data (fixes #68)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2021-11-25  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/LinReg.cpp: Remove 'using namespace std;' for g++-11 builds
+	* src/LinReg_LA.cpp: Idem
+	* src/LinReg_LA_adapt.cpp: Idem
+
 2021-10-10  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Update JSS url to doi form per JSS request

--- a/src/LinReg.cpp
+++ b/src/LinReg.cpp
@@ -38,7 +38,6 @@ namespace LinReg {
     const double b_prior = std::pow(2.0*300.0*300.0,-1.0);
 }
 
-using namespace std;
 using namespace LinReg;
 
 

--- a/src/LinReg_LA.cpp
+++ b/src/LinReg_LA.cpp
@@ -38,7 +38,6 @@ namespace LinReg_LA {
     const double b_prior = pow(2.0*300.0*300.0,-1.0);
 }
 
-using namespace std;
 using namespace LinReg_LA;
 
 // LinRegLA() function callable from R via Rcpp:: 

--- a/src/LinReg_LA_adapt.cpp
+++ b/src/LinReg_LA_adapt.cpp
@@ -29,7 +29,6 @@ namespace LinReg_LA_adapt {
     const double b_prior = std::pow(2.0*300.0*300.0,-1.0);
 }
 
-using namespace std;
 using namespace LinReg_LA_adapt;
 
 // LinRegLA_adapt_impl() function callable from R via Rcpp::


### PR DESCRIPTION
I may look into the remaining source files but this constitutes a minimal fix to #68.

```sh
edd@rob:~/git/rcppsmc(feature/no_using_namespace)$ install.r
* installing *source* package found in current working directory ...
* installing *source* package ‘RcppSMC’ ...
** using staged installation
** libs
ccache g++-11 -I"/usr/share/R/include" -DNDEBUG -I../inst/include -I'/usr/local/lib/R/site-library/Rcpp/include' -I'/usr/local/lib/R/site-library/RcppArmadillo/include'    -fpic  -g -O3 -Wall -pipe  -Wno-parentheses -Wno-ignored-attributes -Wno-unused-local-typedefs -Wno-deprecated-declarations -Wno-unused-function -c LinReg.cpp -o LinReg.o
ccache g++-11 -I"/usr/share/R/include" -DNDEBUG -I../inst/include -I'/usr/local/lib/R/site-library/Rcpp/include' -I'/usr/local/lib/R/site-library/RcppArmadillo/include'    -fpic  -g -O3 -Wall -pipe  -Wno-parentheses -Wno-ignored-attributes -Wno-unused-local-typedefs -Wno-deprecated-declarations -Wno-unused-function -c LinReg_LA.cpp -o LinReg_LA.o
ccache g++-11 -I"/usr/share/R/include" -DNDEBUG -I../inst/include -I'/usr/local/lib/R/site-library/Rcpp/include' -I'/usr/local/lib/R/site-library/RcppArmadillo/include'    -fpic  -g -O3 -Wall -pipe  -Wno-parentheses -Wno-ignored-attributes -Wno-unused-local-typedefs -Wno-deprecated-declarations -Wno-unused-function -c LinReg_LA_adapt.cpp -o LinReg_LA_adapt.o
ccache g++-11 -I"/usr/share/R/include" -DNDEBUG -I../inst/include -I'/usr/local/lib/R/site-library/Rcpp/include' -I'/usr/local/lib/R/site-library/RcppArmadillo/include'    -fpic  -g -O3 -Wall -pipe  -Wno-parentheses -Wno-ignored-attributes -Wno-unused-local-typedefs -Wno-deprecated-declarations -Wno-unused-function -c RcppExports.cpp -o RcppExports.o
ccache g++-11 -I"/usr/share/R/include" -DNDEBUG -I../inst/include -I'/usr/local/lib/R/site-library/Rcpp/include' -I'/usr/local/lib/R/site-library/RcppArmadillo/include'    -fpic  -g -O3 -Wall -pipe  -Wno-parentheses -Wno-ignored-attributes -Wno-unused-local-typedefs -Wno-deprecated-declarations -Wno-unused-function -c blockpfgaussianopt.cpp -o blockpfgaussianopt.o
ccache g++-11 -I"/usr/share/R/include" -DNDEBUG -I../inst/include -I'/usr/local/lib/R/site-library/Rcpp/include' -I'/usr/local/lib/R/site-library/RcppArmadillo/include'    -fpic  -g -O3 -Wall -pipe  -Wno-parentheses -Wno-ignored-attributes -Wno-unused-local-typedefs -Wno-deprecated-declarations -Wno-unused-function -c nonLinPMMH.cpp -o nonLinPMMH.o
ccache g++-11 -I"/usr/share/R/include" -DNDEBUG -I../inst/include -I'/usr/local/lib/R/site-library/Rcpp/include' -I'/usr/local/lib/R/site-library/RcppArmadillo/include'    -fpic  -g -O3 -Wall -pipe  -Wno-parentheses -Wno-ignored-attributes -Wno-unused-local-typedefs -Wno-deprecated-declarations -Wno-unused-function -c pflineart.cpp -o pflineart.o
ccache g++-11 -I"/usr/share/R/include" -DNDEBUG -I../inst/include -I'/usr/local/lib/R/site-library/Rcpp/include' -I'/usr/local/lib/R/site-library/RcppArmadillo/include'    -fpic  -g -O3 -Wall -pipe  -Wno-parentheses -Wno-ignored-attributes -Wno-unused-local-typedefs -Wno-deprecated-declarations -Wno-unused-function -c pfnonlinbs.cpp -o pfnonlinbs.o
ccache g++-11 -Wl,-S -shared -L/usr/lib/R/lib -Wl,-Bsymbolic-functions -flto=auto -Wl,-z,relro -o RcppSMC.so LinReg.o LinReg_LA.o LinReg_LA_adapt.o RcppExports.o blockpfgaussianopt.o nonLinPMMH.o pflineart.o pfnonlinbs.o -llapack -lblas -lgfortran -lm -lquadmath -L/usr/lib/R/lib -lR
installing to /usr/local/lib/R/site-library/00LOCK-rcppsmc/00new/RcppSMC/libs
** R
** data
*** moving datasets to lazyload DB
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (RcppSMC)
edd@rob:~/git/rcppsmc(feature/no_using_namespace)$ 
```