### PR TITLE
Release 0.2.6

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-12-18  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Release 0.2.6
+
 2021-11-25  Dirk Eddelbuettel  <edd@debian.org>
 
 	* src/LinReg.cpp: Remove 'using namespace std;' for g++-11 builds

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RcppSMC
 Type: Package
 Title: Rcpp Bindings for Sequential Monte Carlo
-Version: 0.2.5
-Date: 2021-09-09
+Version: 0.2.6
+Date: 2021-12-18
 Author: Dirk Eddelbuettel, Adam M. Johansen, Leah F. South and Ilya Zarubin
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: R access to the Sequential Monte Carlo Template Classes

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,13 @@
 \newcommand{\ghpr}{\href{https://github.com/rcppsmc/rcppsmc/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/rcppsmc/rcppsmc/issues/#1}{##1}}
 
+\section{Changes in RcppSMC version 0.2.6 (2021-12-17)}{
+  \itemize{
+    \item Updated URLs to JSS for the new DOI scheme upon their request
+    \item Adjusted three source files for C++17 compilation under g++-11
+  }
+}
+
 \section{Changes in RcppSMC version 0.2.5 (2021-09-09)}{
   \itemize{
     \item Compilation under Solaris is aiding via \code{std::pow} use


### PR DESCRIPTION
closes #70

We can let this sit and simmer for another day and I can ship it tomorrow morning my time. Nothing controversial or new in here, but useful to get it out before CRAN takes the winter break as version 0.2.5 does upset `g++-11`.